### PR TITLE
bugfix: core api controllers

### DIFF
--- a/examples/sparkle/__main__.py
+++ b/examples/sparkle/__main__.py
@@ -1,12 +1,11 @@
-from argparse import ArgumentParser, Namespace
 from damavand.cloud.provider import AwsProvider
 from damavand.factories import SparkControllerFactory
 
 from applications.orders import CustomerOrders
-from examples.sparkle.applications.products import Products
+from applications.products import Products
 
 
-def main(args: Namespace) -> None:
+def main() -> None:
     spark_factory = SparkControllerFactory(
         provider=AwsProvider(
             app_name="my-app",
@@ -24,14 +23,9 @@ def main(args: Namespace) -> None:
         CustomerOrders(spark_controller.default_session()),
     ]
 
-    spark_controller.run_application(args.app_id)
+    spark_controller.run_application("products")
     spark_controller.provision()
 
 
 if __name__ == "__main__":
-    arg_parser = ArgumentParser()
-    arg_parser.add_argument("--app_id", type=str, required=True)
-
-    args = arg_parser.parse_args()
-
-    main(args)
+    main()

--- a/examples/sparkle/__main__.py
+++ b/examples/sparkle/__main__.py
@@ -25,6 +25,7 @@ def main(args: Namespace) -> None:
     ]
 
     spark_controller.run_application(args.app_id)
+    spark_controller.provision()
 
 
 if __name__ == "__main__":

--- a/examples/sparkle/applications/orders.py
+++ b/examples/sparkle/applications/orders.py
@@ -11,21 +11,18 @@ class CustomerOrders(Sparkle):
         super().__init__(
             spark_session,
             config=Config(
-                app_name="customer-orders",
-                app_id="customer_orders",
-                version="0.1",
-                database_bucket="s3://bucket-name",
-                kafka=None,
-                input_database=None,
-                output_database=None,
-                iceberg_config=None,
-                spark_trigger='{"once": True}',
+                app_name="orders",
+                app_id="orders-app",
+                version="0.0.1",
+                database_bucket="s3://test-bucket",
+                checkpoints_bucket="s3://test-checkpoints",
             ),
             writers=[
                 IcebergWriter(
                     database_name="default",
                     database_path="s3://bucket-name/warehouse",
                     table_name="products",
+                    spark_session=spark_session,
                 )
             ],
         )

--- a/examples/sparkle/applications/products.py
+++ b/examples/sparkle/applications/products.py
@@ -12,20 +12,17 @@ class Products(Sparkle):
             spark_session,
             config=Config(
                 app_name="products",
-                app_id="products",
-                version="0.1",
-                database_bucket="s3://bucket-name",
-                kafka=None,
-                input_database=None,
-                output_database=None,
-                iceberg_config=None,
-                spark_trigger='{"once": True}',
+                app_id="products-app",
+                version="0.0.1",
+                database_bucket="s3://test-bucket",
+                checkpoints_bucket="s3://test-checkpoints",
             ),
             writers=[
                 IcebergWriter(
                     database_name="default",
                     database_path="s3://bucket-name/warehouse",
                     table_name="products",
+                    spark_session=spark_session,
                 )
             ],
         )

--- a/examples/sparkle/requirements.txt
+++ b/examples/sparkle/requirements.txt
@@ -1,0 +1,3 @@
+-e ../../../damavand
+pyspark==3.3.2
+pulumi

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:fa2d08ca304da34651b9d2dca35a34a206533e52e846b033d5efaec62748d58f"
+content_hash = "sha256:9a823b2b33cca3330f85311bacd976f98588ef280805434ab5f0b038c9be8e5f"
 
 [[metadata.targets]]
 requires_python = ">=3.11.0"
@@ -854,12 +854,12 @@ files = [
 
 [[package]]
 name = "py4j"
-version = "0.10.9.7"
+version = "0.10.9.5"
 summary = "Enables Python programs to dynamically access arbitrary Java objects"
 groups = ["default"]
 files = [
-    {file = "py4j-0.10.9.7-py2.py3-none-any.whl", hash = "sha256:85defdfd2b2376eb3abf5ca6474b51ab7e0de341c75a02f46dc9b5976f5a5c1b"},
-    {file = "py4j-0.10.9.7.tar.gz", hash = "sha256:0b6e5315bb3ada5cf62ac651d107bb2ebc02def3dee9d9548e3baac644ea8dbb"},
+    {file = "py4j-0.10.9.5-py2.py3-none-any.whl", hash = "sha256:52d171a6a2b031d8a5d1de6efe451cf4f5baff1a2819aabc3741c8406539ba04"},
+    {file = "py4j-0.10.9.5.tar.gz", hash = "sha256:276a4a3c5a2154df1860ef3303a927460e02e97b047dc0a47c1c3fb8cce34db6"},
 ]
 
 [[package]]
@@ -921,15 +921,15 @@ files = [
 
 [[package]]
 name = "pyspark"
-version = "3.5.1"
-requires_python = ">=3.8"
+version = "3.3.2"
+requires_python = ">=3.7"
 summary = "Apache Spark Python API"
 groups = ["default"]
 dependencies = [
-    "py4j==0.10.9.7",
+    "py4j==0.10.9.5",
 ]
 files = [
-    {file = "pyspark-3.5.1.tar.gz", hash = "sha256:dd6569e547365eadc4f887bf57f153e4d582a68c4b490de475d55b9981664910"},
+    {file = "pyspark-3.3.2.tar.gz", hash = "sha256:0dfd5db4300c1f6cc9c16d8dbdfb82d881b4b172984da71344ede1a9d4893da8"},
 ]
 
 [[package]]
@@ -1147,12 +1147,12 @@ name = "sparkle"
 version = "0.0.0"
 requires_python = ">=3.10.14"
 git = "https://github.com/DataChefHQ/sparkle.git"
-ref = "bugfix/python-version-locked"
-revision = "8a04a3d9425df46fbc743c55de57d5f1936cd026"
+ref = "v0.3.1"
+revision = "48627c830977d136ad91e1ff6016e53c561bd95e"
 summary = "✨ A meta framework for Apache Spark, helping data engineers to focus on solving business problems with highest quality!"
 groups = ["default"]
 dependencies = [
-    "pyspark>=3.3.2",
+    "pyspark==3.3.2",
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,8 @@ dependencies = [
     "pulumi>=3.127.0",
     "pulumi-aws>=6.47.0",
     "pulumi-azure-native>=2.51.0",
-    "pyspark>=3.5.1",
     "pulumi-random>=4.16.3",
-    "sparkle @ git+https://github.com/DataChefHQ/sparkle.git@bugfix/python-version-locked",
+    "sparkle @ git+https://github.com/DataChefHQ/sparkle.git@v0.3.1",
 ]
 requires-python = ">=3.11.0"
 readme = "README.md"

--- a/src/damavand/base/controllers/base_controller.py
+++ b/src/damavand/base/controllers/base_controller.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 from functools import cache
 from pulumi import Resource as PulumiResource
 import pulumi
@@ -40,14 +39,11 @@ class ApplicationController(object):
     def __init__(
         self,
         name: str,
-        id: Optional[str] = None,
         tags: dict[str, str] = {},
         **kwargs,
     ) -> None:
         self.name = name
         self.tags = tags
-        # FIXME: the id should be removed.
-        self._id = id
         self.extra_args = kwargs
         self._pulumi_object = None
 

--- a/src/damavand/base/controllers/base_controller.py
+++ b/src/damavand/base/controllers/base_controller.py
@@ -63,4 +63,4 @@ class ApplicationController(object):
     def provision(self) -> None:
         """Provision the resource in not provisioned yet."""
 
-        _ = self.resource
+        _ = self.resource()

--- a/src/damavand/base/controllers/object_storage.py
+++ b/src/damavand/base/controllers/object_storage.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional
+from typing import Iterable
 
 from damavand.base.controllers import ApplicationController
 
@@ -7,11 +7,10 @@ class ObjectStorageController(ApplicationController):
     def __init__(
         self,
         name,
-        id_: Optional[str] = None,
         tags: dict[str, str] = {},
         **kwargs,
     ) -> None:
-        super().__init__(name, id_, tags, **kwargs)
+        super().__init__(name, tags, **kwargs)
 
     def read(self, path: str) -> bytes:
         """Read an object from the storage."""

--- a/src/damavand/base/controllers/spark.py
+++ b/src/damavand/base/controllers/spark.py
@@ -52,7 +52,7 @@ class SparkController(ApplicationController):
         **kwargs,
     ) -> None:
         ApplicationController.__init__(self, name, tags, **kwargs)
-        self.applications: list[Sparkle]
+        self.applications: list[Sparkle] = []
 
     @property
     def _spark_extensions(self) -> list[str]:

--- a/src/damavand/base/controllers/spark.py
+++ b/src/damavand/base/controllers/spark.py
@@ -1,6 +1,5 @@
 import os
 import logging
-from typing import Optional
 from pyspark.conf import SparkConf
 from pyspark.sql import SparkSession
 
@@ -27,8 +26,6 @@ class SparkController(ApplicationController):
         the name of the controller.
     applications : list[Sparkle]
         the list of Spark applications.
-    id_ : Optional[str]
-        the ID of the controller.
     tags : dict[str, str]
         the tags of the controller.
     kwargs : dict
@@ -51,11 +48,10 @@ class SparkController(ApplicationController):
     def __init__(
         self,
         name,
-        id_: Optional[str] = None,
         tags: dict[str, str] = {},
         **kwargs,
     ) -> None:
-        ApplicationController.__init__(self, name, id_, tags, **kwargs)
+        ApplicationController.__init__(self, name, tags, **kwargs)
         self.applications: list[Sparkle]
 
     @property

--- a/src/damavand/base/factory.py
+++ b/src/damavand/base/factory.py
@@ -46,6 +46,7 @@ class ApplicationControllerFactory(Generic[ControllerType]):
             case AwsProvider():
                 ctr = self._new_aws_controller(
                     name=name,
+                    region=self.provider.explicit_region,
                     id=id,
                     tags=self.tags,
                     **kwargs,
@@ -73,6 +74,7 @@ class ApplicationControllerFactory(Generic[ControllerType]):
     def _new_aws_controller(
         self,
         name: str,
+        region: str,
         id: Optional[str] = None,
         tags: dict[str, str] = {},
         **kwargs,

--- a/src/damavand/base/factory.py
+++ b/src/damavand/base/factory.py
@@ -44,7 +44,6 @@ class ApplicationControllerFactory(Generic[ControllerType]):
                 ctr = self._new_aws_controller(
                     name=name,
                     region=self.provider.explicit_region,
-                    id=id,
                     tags=self.tags,
                     **kwargs,
                 )
@@ -53,7 +52,6 @@ class ApplicationControllerFactory(Generic[ControllerType]):
             case AzurermProvider():
                 ctr = self._new_azure_controller(
                     name=name,
-                    id=id,
                     tags=self.tags,
                     **kwargs,
                 )
@@ -66,7 +64,6 @@ class ApplicationControllerFactory(Generic[ControllerType]):
         self,
         name: str,
         region: str,
-        id: Optional[str] = None,
         tags: dict[str, str] = {},
         **kwargs,
     ) -> ControllerType:
@@ -75,7 +72,6 @@ class ApplicationControllerFactory(Generic[ControllerType]):
     def _new_azure_controller(
         self,
         name: str,
-        id: Optional[str] = None,
         tags: dict[str, str] = {},
         **kwargs,
     ) -> ControllerType:

--- a/src/damavand/base/factory.py
+++ b/src/damavand/base/factory.py
@@ -22,8 +22,6 @@ class ApplicationControllerFactory(Generic[ControllerType]):
         The cloud provider object.
     tags : dict[str, str]
         A set of default tags to be applied to all resources.
-    provision_on_creation : bool
-        A flag to provision resources on creation of the controller. If set to False, the resources must be provisioned manually.
 
     Methods
     -------
@@ -33,7 +31,6 @@ class ApplicationControllerFactory(Generic[ControllerType]):
 
     provider: CloudProvider
     tags: dict[str, str] = field(default_factory=dict)
-    provision_on_creation: bool = True
     controllers: list[ApplicationController] = field(init=False, default_factory=list)
 
     def new(
@@ -52,9 +49,6 @@ class ApplicationControllerFactory(Generic[ControllerType]):
                     **kwargs,
                 )
 
-                if self.provision_on_creation:
-                    ctr.provision()
-
                 return ctr
             case AzurermProvider():
                 ctr = self._new_azure_controller(
@@ -63,9 +57,6 @@ class ApplicationControllerFactory(Generic[ControllerType]):
                     tags=self.tags,
                     **kwargs,
                 )
-
-                if self.provision_on_creation:
-                    ctr.provision()
 
                 return ctr
             case _:

--- a/src/damavand/cloud/aws/controllers/object_storage.py
+++ b/src/damavand/cloud/aws/controllers/object_storage.py
@@ -3,7 +3,7 @@ import boto3
 import io
 import logging
 from botocore.exceptions import ClientError
-from typing import Iterable, Optional
+from typing import Iterable
 from pulumi_aws import s3
 from pulumi import Resource as PulumiResource
 
@@ -24,11 +24,10 @@ class AwsObjectStorageController(ObjectStorageController):
         self,
         name,
         region: str,
-        id_: Optional[str] = None,
         tags: dict[str, str] = {},
         **kwargs,
     ) -> None:
-        super().__init__(name, id_, tags, **kwargs)
+        super().__init__(name, tags, **kwargs)
         self.__s3_client = boto3.client("s3", region_name=region)
 
     @buildtime

--- a/src/damavand/cloud/aws/controllers/spark.py
+++ b/src/damavand/cloud/aws/controllers/spark.py
@@ -5,8 +5,6 @@ from functools import cache
 import boto3
 from pulumi import Resource as PulumiResource
 
-from sparkle.application import Sparkle
-
 from damavand.base.controllers import SparkController, buildtime
 from damavand.cloud.aws.resources import GlueComponent, GlueComponentArgs
 from damavand.cloud.aws.resources.glue_component import GlueJobDefinition
@@ -21,12 +19,11 @@ class AwsSparkController(SparkController):
         self,
         name,
         region: str,
-        applications: list[Sparkle] = [],
         id_: Optional[str] = None,
         tags: dict[str, str] = {},
         **kwargs,
     ) -> None:
-        super().__init__(name, applications, id_, tags, **kwargs)
+        super().__init__(name, id_, tags, **kwargs)
         self._glue_client = boto3.client("glue", region_name=region)
 
     @buildtime

--- a/src/damavand/cloud/aws/controllers/spark.py
+++ b/src/damavand/cloud/aws/controllers/spark.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 from functools import cache
 
 import boto3
@@ -19,11 +18,10 @@ class AwsSparkController(SparkController):
         self,
         name,
         region: str,
-        id_: Optional[str] = None,
         tags: dict[str, str] = {},
         **kwargs,
     ) -> None:
-        super().__init__(name, id_, tags, **kwargs)
+        super().__init__(name, tags, **kwargs)
         self._glue_client = boto3.client("glue", region_name=region)
 
     @buildtime

--- a/src/damavand/cloud/azure/controllers/spark.py
+++ b/src/damavand/cloud/azure/controllers/spark.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 from functools import cache
 
 import pulumi
@@ -20,11 +19,10 @@ class AzureSparkController(SparkController):
         self,
         name,
         region: str,
-        id_: Optional[str] = None,
         tags: dict[str, str] = {},
         **kwargs,
     ) -> None:
-        super().__init__(name, id_, tags, **kwargs)
+        super().__init__(name, tags, **kwargs)
         self.applications: list[Sparkle]
 
     @buildtime

--- a/src/damavand/cloud/provider.py
+++ b/src/damavand/cloud/provider.py
@@ -34,8 +34,8 @@ class AwsProvider(BaseProvider, PulumiAwsProvider):
         self.__region = region
 
     @property
-    def enforced_region(self) -> str:
-        """Region that enforced to all AWS operations"""
+    def explicit_region(self) -> str:
+        """The region explicitly set for the provider during the Provider initialization."""
         return self.__region
 
 

--- a/src/damavand/factories.py
+++ b/src/damavand/factories.py
@@ -8,10 +8,16 @@ from damavand.cloud.azure.controllers import AzureSparkController
 
 class SparkControllerFactory(ApplicationControllerFactory[SparkController]):
     def _new_aws_controller(
-        self, name: str, id: Optional[str] = None, tags: dict[str, str] = {}, **kwargs
+        self,
+        name: str,
+        region: str,
+        id: Optional[str] = None,
+        tags: dict[str, str] = {},
+        **kwargs,
     ) -> SparkController:
         return AwsSparkController(
             name=name,
+            region=region,
             id=id,
             tags=tags,
             **kwargs,

--- a/src/damavand/factories.py
+++ b/src/damavand/factories.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from damavand.base.controllers.spark import SparkController
 from damavand.base.factory import ApplicationControllerFactory
@@ -11,24 +10,21 @@ class SparkControllerFactory(ApplicationControllerFactory[SparkController]):
         self,
         name: str,
         region: str,
-        id: Optional[str] = None,
         tags: dict[str, str] = {},
         **kwargs,
     ) -> SparkController:
         return AwsSparkController(
             name=name,
             region=region,
-            id=id,
             tags=tags,
             **kwargs,
         )
 
     def _new_azure_controller(
-        self, name: str, id: Optional[str] = None, tags: dict[str, str] = {}, **kwargs
+        self, name: str, tags: dict[str, str] = {}, **kwargs
     ) -> SparkController:
         return AzureSparkController(
             name=name,
-            id=id,
             tags=tags,
             **kwargs,
         )

--- a/tests/clouds/aws/controllers/test_aws_spark.py
+++ b/tests/clouds/aws/controllers/test_aws_spark.py
@@ -6,26 +6,13 @@ from sparkle.application import Sparkle
 from sparkle.config import Config
 
 from damavand.cloud.aws.controllers.spark import AwsSparkController, GlueComponent
-
-
-class MockSparkle(Sparkle):
-    pass
+from damavand.errors import BuildtimeException
 
 
 @pytest.fixture
 def controller():
-    mock_sparkle = Mock(spec=Sparkle)
-    mock_sparkle.config = Config(
-        app_name="test-spark-app",
-        app_id="test-spark-app-id",
-        version="0.0.1",
-        database_bucket="s3://test-bucket",
-        checkpoints_bucket="s3://test-checkpoints",
-    )
-
     ctr = AwsSparkController(
         "test-spark",
-        applications=[mock_sparkle],
         region="us-east-1",
     )
 
@@ -36,4 +23,24 @@ def test_resource_return_glue_component(
     controller: AwsSparkController, monkeypatch: MonkeyPatch
 ):
     monkeypatch.setenv("MODE", "BUILD")
+
+    mock_sparkle = Mock(spec=Sparkle)
+    mock_sparkle.config = Config(
+        app_name="test-spark-app",
+        app_id="test-spark-app-id",
+        version="0.0.1",
+        database_bucket="s3://test-bucket",
+        checkpoints_bucket="s3://test-checkpoints",
+    )
+
+    controller.applications = [mock_sparkle]
+    controller.provision()
     assert isinstance(controller.resource(), GlueComponent)
+
+
+def test_should_throw_when_no_applications(
+    controller: AwsSparkController, monkeypatch: MonkeyPatch
+):
+    monkeypatch.setenv("MODE", "BUILD")
+    with pytest.raises(BuildtimeException):
+        controller.provision()

--- a/tests/clouds/aws/controllers/test_aws_spark.py
+++ b/tests/clouds/aws/controllers/test_aws_spark.py
@@ -16,14 +16,11 @@ class MockSparkle(Sparkle):
 def controller():
     mock_sparkle = Mock(spec=Sparkle)
     mock_sparkle.config = Config(
-        app_name="test-spark",
-        app_id="test-spark",
+        app_name="test-spark-app",
+        app_id="test-spark-app-id",
         version="0.0.1",
-        database_bucket="test-bucket",
-        kafka=None,
-        input_database=None,
-        output_database=None,
-        iceberg_config=None,
+        database_bucket="s3://test-bucket",
+        checkpoints_bucket="s3://test-checkpoints",
     )
 
     ctr = AwsSparkController(


### PR DESCRIPTION
# Description

This PR is targeting multiple bugs with Damavand's core APIs:
- [x] Sparkle locked to a bugfix branch instead of a version.
- [x] Factory controller does not pass the region to controllers.
- [x] Provisioning of the resources is happening before creation of the applications, leading to miss configuration of resources layer.
- [x] Using `id` in controllers interfaces causing confusion.